### PR TITLE
Realm "add" method updates entities if already existing

### DIFF
--- a/Example/Source/SubExamples/API response/APIResponseCoreDataViewController.swift
+++ b/Example/Source/SubExamples/API response/APIResponseCoreDataViewController.swift
@@ -52,7 +52,7 @@ class APIResponseCoreDataViewController: UIViewController {
 					} catch { return nil }
 				}
 
-				try? context.add(users)
+				try? context.addOrUpdate(users)
 
 				DispatchQueue.main.async {
 					completion()

--- a/Example/Source/SubExamples/API response/APIResponseRealmViewController.swift
+++ b/Example/Source/SubExamples/API response/APIResponseRealmViewController.swift
@@ -51,7 +51,7 @@ class APIResponseRealmViewController: UIViewController {
 
 				do {
 					try context.deleteAll(APIUserRealm.self)
-					try context.add(users)
+					try context.addOrUpdate(users)
 				} catch {
 					print(error)
 				}

--- a/Example/Source/SubExamples/API response/Components/APIResponseTableViewController.swift
+++ b/Example/Source/SubExamples/API response/Components/APIResponseTableViewController.swift
@@ -24,7 +24,7 @@ class APIResponseTableViewController: UITableViewController {
 			switch storageType {
 			case .CoreData:
                 do {
-                    try context.fetch(sortDescriptors: [sort]) { [unowned self] (users: [APIUserCoreData]?) in
+                    try context.fetch(predicate: nil, sortDescriptors: [sort]) { [unowned self] (users: [APIUserCoreData]?) in
                         guard let users = users else { return }
 
                         do {
@@ -39,7 +39,7 @@ class APIResponseTableViewController: UITableViewController {
                 } catch {}
 			case .Realm:
                 do {
-                    try context.fetch(sortDescriptors: [sort]) { [unowned self] (users: [APIUserRealm]?) in
+                    try context.fetch(predicate: nil, sortDescriptors: [sort]) { [unowned self] (users: [APIUserRealm]?) in
                         guard let users = users else { return }
 
                         do {

--- a/Example/Source/SubExamples/ToDo App/Components/AddToDoViewController.swift
+++ b/Example/Source/SubExamples/ToDo App/Components/AddToDoViewController.swift
@@ -48,7 +48,7 @@ class AddToDoViewController: UIViewController {
                     if let task = todoTask, let name = self.taskNameTextField.text {
                         task.name = name
                         task.added = NSDate()
-                        try backgroundContext.add(task)
+                        try backgroundContext.addOrUpdate(task)
                     }
                 case .Realm:
                     let todoTask: RTodoTask? = try backgroundContext.create()
@@ -56,7 +56,7 @@ class AddToDoViewController: UIViewController {
                     if let task = todoTask, let name = self.taskNameTextField.text {
                         task.name = name
                         task.added = NSDate()
-                        try backgroundContext.add(task)
+                        try backgroundContext.addOrUpdate(task)
                     }
                 }
                 

--- a/Example/Source/SubExamples/ToDo App/Components/ToDoAppViewController.swift
+++ b/Example/Source/SubExamples/ToDo App/Components/ToDoAppViewController.swift
@@ -44,6 +44,8 @@ class ToDoAppViewController: UIViewController {
 
             switch storageType {
             case .CoreData:
+
+                
                 backgroundContext.fetch(predicate: NSPredicate(format: "done == false"), sortDescriptors: [strongSelf.sortDescriptor], completion: {[weak self] (fetchedTasks: [ToDoTask]?) in
                     
                     guard self != nil else {

--- a/Source/Core/Contexts/StorageContext.swift
+++ b/Source/Core/Contexts/StorageContext.swift
@@ -131,7 +131,25 @@ public protocol StorageReadableContext: class {
     /**
         Use this method to fetch entities from the database.
         You can also specify a predicate to filter the entity to fetch and an array of sort descriptors to order the result.
-        By default, `predicate` and `sortDescriptors` are `nil`
+     
+        Example:
+        ```
+        context.fetch { (result: [MyEntity]?) in
+     
+        }
+        ```
+        **Note:**
+     
+        Since the return is a generic optional array, you must add the type of entities which you want to fetch explicitly. As you can see in the example above, we have specified the type `[MyEntity]?` as result type. Remember to use `?` since it may be an optional array.
+     
+        - Parameter completion: Closure which contains the entity fetched. It has as parameter an optional array which contains the fetch result.
+        - Throws: StorageKitErrors.Entity.wrongType
+     */
+    func fetch<T: StorageEntityType>(completion: @escaping FetchCompletionClosure<T>) throws
+    
+    /**
+        Use this method to fetch entities from the database.
+        You can also specify a predicate to filter the entity to fetch and an array of sort descriptors to order the result.
 
         Example:
         ```
@@ -144,20 +162,12 @@ public protocol StorageReadableContext: class {
         Since the return is a generic optional array, you must add the type of entities which you want to fetch explicitly. As you can see in the example above, we have specified the type `[MyEntity]?` as result type. Remember to use `?` since it may be an optional array.
      
         - Parameter predicate: `NSPredicate` object to filter the entity to fetch. Pass `nil` if you don't want any filter applied.
-        - Parameter transform: Array of `SortDescriptor` to order the result. Pass `nil` if you don't want any order applied.
+        - Parameter sortDescriptors: Array of `SortDescriptor` to order the result. Pass `nil` if you don't want any order applied.
         - Parameter completion: Closure which contains the entity fetched. It has as parameter an optional array which contains the fetch result.
         - Throws: StorageKitErrors.Entity.wrongType
     */
 
     func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) throws
-}
-
-extension StorageReadableContext {
-
-    public func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) throws {
-
-        fatalError("fetch method not implemented")
-    }
 }
 
 /// This protocol adds the functionality to update entities in the database.

--- a/Source/Core/Contexts/StorageContext.swift
+++ b/Source/Core/Contexts/StorageContext.swift
@@ -90,7 +90,8 @@ public protocol StorageWritableContext: class {
             try context.add(entity)
         } catch {}
         ```
-        If an entity with the same identifier already exists then the object is updated with `entity`
+
+        If an object with the same primary key exists in the storage, the object will be updated with `entity`
 
         - Parameter entity: Entity to add in the database.
         - Throws: The error depends on database used (CoreData and Realm).
@@ -114,7 +115,7 @@ public protocol StorageWritableContext: class {
         } catch {}
         ```
 
-        For every `entity` in `entities`, If an object with the same identifier already exists in the storage then the object is updated with `entity`
+        For every `entity` in `entities`, If an object with the same primary key exists in the storage, the object will be updated with `entity`
      
         - Parameter entities: Array of entities to add in the database.
         - Throws: The error depends on database used (CoreData and Realm).

--- a/Source/Core/Contexts/StorageContext.swift
+++ b/Source/Core/Contexts/StorageContext.swift
@@ -114,9 +114,8 @@ public protocol StorageWritableContext: class {
         } catch {}
         ```
 
-        For each entity included in the array, if there an object already stored with the same identifier then this object 
-        is updated with the one taken from the array.
-
+        For every `entity` in `entities`, If an object with the same identifier already exists in the storage then the object is updated with `entity`
+     
         - Parameter entities: Array of entities to add in the database.
         - Throws: The error depends on database used (CoreData and Realm).
     */

--- a/Source/Core/Contexts/StorageContext.swift
+++ b/Source/Core/Contexts/StorageContext.swift
@@ -151,8 +151,8 @@ public protocol StorageReadableContext: class {
     func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>)
 }
 
-public extension StorageReadableContext {
-    func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) {
+extension StorageReadableContext {
+    public func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) {
         fatalError("fetch method not implemented")
     }
 }

--- a/Source/Core/Contexts/StorageContext.swift
+++ b/Source/Core/Contexts/StorageContext.swift
@@ -90,11 +90,12 @@ public protocol StorageWritableContext: class {
             try context.add(entity)
         } catch {}
         ```
+        If an entity with the same identifier already exists then the object is updated with `entity`
 
         - Parameter entity: Entity to add in the database.
         - Throws: The error depends on database used (CoreData and Realm).
     */
-    func add<T: StorageEntityType>(_ entity: T) throws
+    func addOrUpdate<T: StorageEntityType>(_ entity: T) throws
     
     /**
         Use this method to add an array of entities in the database.
@@ -113,11 +114,14 @@ public protocol StorageWritableContext: class {
         } catch {}
         ```
 
+        For each entity included in the array, if there an object already stored with the same identifier then this object 
+        is updated with the one taken from the array.
+
         - Parameter entities: Array of entities to add in the database.
         - Throws: The error depends on database used (CoreData and Realm).
     */
     
-    func add<T: StorageEntityType>(_ entities: [T]) throws
+    func addOrUpdate<T: StorageEntityType>(_ entities: [T]) throws
 }
 
 /// This protocol adds the functionality to fetch entities from the database.

--- a/Source/Storages/CoreData/Extensions/NSManagedObjectContext+StorageContext.swift
+++ b/Source/Storages/CoreData/Extensions/NSManagedObjectContext+StorageContext.swift
@@ -102,7 +102,11 @@ extension NSManagedObjectContext: StorageUpdatableContext {
 
 // MARK: - StorageReadableContext
 extension NSManagedObjectContext: StorageReadableContext {
-	public func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) throws {
+    public func fetch<T>(completion: @escaping FetchCompletionClosure<T>) throws where T : StorageEntityType {
+        return try fetch(predicate: nil, sortDescriptors: nil, completion: completion)
+    }
+
+	public func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) throws {
         guard T.self is NSManagedObject.Type else {
             throw StorageKitErrors.Entity.wrongType
         }

--- a/Source/Storages/CoreData/Extensions/NSManagedObjectContext+StorageContext.swift
+++ b/Source/Storages/CoreData/Extensions/NSManagedObjectContext+StorageContext.swift
@@ -56,11 +56,11 @@ extension NSManagedObjectContext: StorageDeletableContext {
 
 // MARK: - StorageWritableContext
 extension NSManagedObjectContext: StorageWritableContext {
-    public func add<T: StorageEntityType>(_ entity: T) throws {
+    public func addOrUpdate<T: StorageEntityType>(_ entity: T) throws {
         try save()
     }
     
-    public func add<T: StorageEntityType>(_ entities: [T]) throws {
+    public func addOrUpdate<T: StorageEntityType>(_ entities: [T]) throws {
         try save()
     }
 

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -99,7 +99,8 @@ extension RealmContext {
 
 // MARK: - StorageReadableContext
 extension RealmContext {
-    func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) {
+    public func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) {
+
         guard let entityToFetch = T.self as? Object.Type else {
             // TODO: i'd need a throw here
             // throw RealmError.wrongObject("\(Object.Type) is not a valid realm entity type.")

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -105,7 +105,11 @@ extension RealmContext {
 
 // MARK: - StorageReadableContext
 extension RealmContext {
-    func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) throws {
+    func fetch<T>(completion: @escaping FetchCompletionClosure<T>) throws where T : StorageEntityType {
+        return try fetch(predicate: nil, sortDescriptors: nil, completion: completion)
+    }
+    
+    func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) throws {
 
         guard let entityToFetch = T.self as? Object.Type else {
             throw StorageKitErrors.Entity.wrongType

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -79,7 +79,7 @@ extension RealmContext {
             
             entities.lazy
                 .flatMap { return $0 as? Object }
-                .forEach { realm.add($0, update: false) }
+                .forEach { realm.add($0, update: true) }
         }
     }
 }

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -70,11 +70,11 @@ extension RealmContext {
         return entityToCreate.init() as? T
     }
     
-    func add<T: StorageEntityType>(_ entity: T) throws {
-        try add([entity])
+    func addOrUpdate<T: StorageEntityType>(_ entity: T) throws {
+        try addOrUpdate([entity])
     }
     
-    func add<T: StorageEntityType>(_ entities: [T]) throws {
+    func addOrUpdate<T: StorageEntityType>(_ entities: [T]) throws {
         try self.safeWriteAction {
             
             entities.lazy

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -79,7 +79,10 @@ extension RealmContext {
             
             entities.lazy
                 .flatMap { return $0 as? Object }
-                .forEach { realm.add($0, update: true) }
+                .forEach {
+                    let canUpdateIfExists = $0.objectSchema.primaryKeyProperty != nil
+                    realm.add($0, update: canUpdateIfExists)
+            }
         }
     }
 }

--- a/StorageKit.xcodeproj/project.pbxproj
+++ b/StorageKit.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		6B7CC6EA1F18E0430061BE39 /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6B7CC6E41F18DF800061BE39 /* RealmSwift.framework */; };
 		7521F32E1F1A75860005FB8D /* Realm.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6B7CC6D81F18DF800061BE39 /* Realm.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7521F32F1F1A75860005FB8D /* RealmSwift.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 6B7CC6E41F18DF800061BE39 /* RealmSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		755514B11F54A0E90013766D /* SpyRealmEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755514B01F54A0E90013766D /* SpyRealmEntity.swift */; };
 		A000FE991F166FBA0027D689 /* StorageEntityType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A000FE981F166FBA0027D689 /* StorageEntityType.swift */; };
 		A000FE9C1F166FF60027D689 /* Storage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A000FE9B1F166FF60027D689 /* Storage.swift */; };
 		A000FEA31F16706F0027D689 /* NSEntityDescription+EntityDescriptionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A000FE9E1F16706F0027D689 /* NSEntityDescription+EntityDescriptionType.swift */; };
@@ -170,6 +171,7 @@
 		6B468B261F1E4FF600DEE3BD /* RealmContext+StorageContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RealmContext+StorageContext.swift"; sourceTree = "<group>"; };
 		6B63641B1F13836100679162 /* RealmDataStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealmDataStorage.swift; sourceTree = "<group>"; };
 		6B7CC6C91F18DF800061BE39 /* Realm.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Realm.xcodeproj; path = "Carthage/Checkouts/realm-cocoa/Realm.xcodeproj"; sourceTree = "<group>"; };
+		755514B01F54A0E90013766D /* SpyRealmEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpyRealmEntity.swift; sourceTree = "<group>"; };
 		A000FE981F166FBA0027D689 /* StorageEntityType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageEntityType.swift; sourceTree = "<group>"; };
 		A000FE9B1F166FF60027D689 /* Storage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Storage.swift; sourceTree = "<group>"; };
 		A000FE9E1F16706F0027D689 /* NSEntityDescription+EntityDescriptionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSEntityDescription+EntityDescriptionType.swift"; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 		A9E0125E1F28EF2C00040CE0 /* TestDoubles */ = {
 			isa = PBXGroup;
 			children = (
+				755514B01F54A0E90013766D /* SpyRealmEntity.swift */,
 				A9E0125F1F28EF3700040CE0 /* SpyRealm.swift */,
 				A9FA2CCF1F2A7D5C00ED6C0B /* SpyRealmContext.swift */,
 				A9E012621F28F76400040CE0 /* SpyRealmResult.swift */,
@@ -798,6 +801,7 @@
 				A0BF67C41F0E5C0D003D5C62 /* PersistentStoreCoordinatorType.swift in Sources */,
 				A000FEA51F16706F0027D689 /* NSManagedObjectContext+ManagedObjectContextType.swift in Sources */,
 				A0BF67C11F0E5C0D003D5C62 /* ManagedObjectContextType.swift in Sources */,
+				755514B11F54A0E90013766D /* SpyRealmEntity.swift in Sources */,
 				6B468B271F1E4FF600DEE3BD /* RealmContext+StorageContext.swift in Sources */,
 				A000FE9C1F166FF60027D689 /* Storage.swift in Sources */,
 				A0BF67BF1F0E5C0D003D5C62 /* CoreDataStorage.swift in Sources */,

--- a/Tests/Core/StorageContextTests.swift
+++ b/Tests/Core/StorageContextTests.swift
@@ -52,16 +52,3 @@ class StorageContextTests: XCTestCase {
     }
     
 }
-
-// MARK: - fetch
-extension StorageContextTests {
-    func test_DefaultImplementation_ThrowsError() {
-        let sut = DummyStorageContextWithoutFetch()
-
-        expectFatalError(expectedMessage: "fetch method not implemented") {
-            do {
-                try sut.fetch { (_: [DummyStorageEntity]?) in }
-            } catch {}
-        }
-    }
-}

--- a/Tests/Core/TestDoubles/DummyStorageContext.swift
+++ b/Tests/Core/TestDoubles/DummyStorageContext.swift
@@ -38,6 +38,9 @@ extension DummyStorageContext: StorageDeletableContext {
 }
 
 extension DummyStorageContext: StorageReadableContext {
+
+    func fetch<T>(completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
+
     func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) {}
 }
 

--- a/Tests/Core/TestDoubles/DummyStorageContext.swift
+++ b/Tests/Core/TestDoubles/DummyStorageContext.swift
@@ -46,9 +46,9 @@ extension DummyStorageContext: StorageUpdatableContext {
 }
 
 extension DummyStorageContext: StorageWritableContext {
-    func add<T>(_ entities: [T]) throws where T : StorageEntityType {}
+    func addOrUpdate<T>(_ entities: [T]) throws where T : StorageEntityType {}
 
-    func add<T>(_ entity: T) throws where T : StorageEntityType {}
+    func addOrUpdate<T>(_ entity: T) throws where T : StorageEntityType {}
 
     func create<T: StorageEntityType>() -> T? {
         return nil

--- a/Tests/Core/TestDoubles/DummyStorageContextWithoutFetch.swift
+++ b/Tests/Core/TestDoubles/DummyStorageContextWithoutFetch.swift
@@ -37,7 +37,10 @@ extension DummyStorageContextWithoutFetch: StorageDeletableContext {
     func deleteAll<T: StorageEntityType>(_ entityType: T.Type) throws {}
 }
 
-extension DummyStorageContextWithoutFetch: StorageReadableContext {}
+extension DummyStorageContextWithoutFetch: StorageReadableContext {
+    func fetch<T>(completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
+    func fetch<T>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
+}
 
 extension DummyStorageContextWithoutFetch: StorageUpdatableContext {
     func update(transform: @escaping () -> Void) throws {}

--- a/Tests/Core/TestDoubles/DummyStorageContextWithoutFetch.swift
+++ b/Tests/Core/TestDoubles/DummyStorageContextWithoutFetch.swift
@@ -44,9 +44,9 @@ extension DummyStorageContextWithoutFetch: StorageUpdatableContext {
 }
 
 extension DummyStorageContextWithoutFetch: StorageWritableContext {
-    func add<T>(_ entities: [T]) throws where T : StorageEntityType {}
-
-    func add<T>(_ entity: T) throws where T : StorageEntityType {}
+    func addOrUpdate<T>(_ entity: T) throws where T : StorageEntityType {}
+    
+    func addOrUpdate<T>(_ entities: [T]) throws where T : StorageEntityType {}
 
     func create<T: StorageEntityType>() -> T? {
         return nil

--- a/Tests/Storages/CoreData/Extensions/NSManagedObjectContextStorageContextTests.swift
+++ b/Tests/Storages/CoreData/Extensions/NSManagedObjectContextStorageContextTests.swift
@@ -292,7 +292,7 @@ extension NSManagedObjectContextStorageContextTests {
         let request = NSPredicate()
 
         do {
-            try sut.fetch(predicate: request) { (_: [DummyStorageEntity]?) in }
+            try sut.fetch(predicate: request, sortDescriptors: nil) { (_: [DummyStorageEntity]?) in }
         } catch {}
 
         XCTAssertFalse(sut.executeRequestArgument?.fetchRequest.predicate === request)
@@ -318,7 +318,7 @@ extension NSManagedObjectContextStorageContextTests {
         let request = NSPredicate()
 
         do {
-            try sut.fetch(predicate: request) { (_: [NSManagedObject]?) in }
+            try sut.fetch(predicate: request, sortDescriptors: nil) { (_: [NSManagedObject]?) in }
         } catch {}
 
         XCTAssertTrue(sut.executeRequestArgument?.fetchRequest.predicate === request)
@@ -329,7 +329,7 @@ extension NSManagedObjectContextStorageContextTests {
         let sortDesc2 = SortDescriptor(key: "t2", ascending: true)
 
         do {
-            try sut.fetch(sortDescriptors: [sortDesc, sortDesc2]) { (_: [NSManagedObject]?) in }
+            try sut.fetch(predicate: nil, sortDescriptors: [sortDesc, sortDesc2]) { (_: [NSManagedObject]?) in }
         } catch {}
 
         XCTAssertEqual(sut.executeRequestArgument?.fetchRequest.sortDescriptors?.first?.key, "t1")

--- a/Tests/Storages/CoreData/Extensions/NSManagedObjectContextStorageContextTests.swift
+++ b/Tests/Storages/CoreData/Extensions/NSManagedObjectContextStorageContextTests.swift
@@ -193,7 +193,7 @@ extension NSManagedObjectContextStorageContextTests {
 extension NSManagedObjectContextStorageContextTests {
     func test_Add_OneEntity_CallsSuperSave() {
         do {
-            try sut.add(DummyStorageEntity())
+            try sut.addOrUpdate(DummyStorageEntity())
         } catch {
             XCTFail()
         }
@@ -203,7 +203,7 @@ extension NSManagedObjectContextStorageContextTests {
 
     func test_Add_ArrayOfEntities_CallsSuperSave() {
         do {
-            try sut.add([DummyStorageEntity(), DummyStorageEntity(), DummyStorageEntity()])
+            try sut.addOrUpdate([DummyStorageEntity(), DummyStorageEntity(), DummyStorageEntity()])
         } catch {
             XCTFail()
         }

--- a/Tests/Storages/CoreData/TestDoubles/SpyManagedObjectContext.swift
+++ b/Tests/Storages/CoreData/TestDoubles/SpyManagedObjectContext.swift
@@ -99,6 +99,7 @@ extension SpyManagedObjectContext {
     func delete<T: StorageEntityType>(_ entities: [T]) throws {}
     func deleteAll<T: StorageEntityType>(_ entityType: T.Type) throws {}
     
+    func fetch<T>(completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
     func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) {}
 
     func update(transform: @escaping () -> Void) throws {}

--- a/Tests/Storages/CoreData/TestDoubles/SpyManagedObjectContext.swift
+++ b/Tests/Storages/CoreData/TestDoubles/SpyManagedObjectContext.swift
@@ -105,5 +105,5 @@ extension SpyManagedObjectContext {
     
     func create<T: StorageEntityType>() -> T? { return nil }
     
-    func add<T>(_ entity: T) throws { }
+    func addOrUpdate<T>(_ entity: T) throws { }
 }

--- a/Tests/Storages/Realm/RealmContextTests.swift
+++ b/Tests/Storages/Realm/RealmContextTests.swift
@@ -443,7 +443,7 @@ extension RealmContextTests {
 
 	func test_Fetch_PredicateNotNil_CallsResultPredicate() {
         do {
-            try sut.fetch(predicate: NSPredicate(value: true)) { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch(predicate: NSPredicate(value: true), sortDescriptors: nil) { (entity: [Object]?) in print(entity?.count ?? 0) }
         } catch {}
 
 		XCTAssertTrue(getSpyRealm().forcedResult.isFilterCalled)
@@ -453,7 +453,7 @@ extension RealmContextTests {
 		let predicate = NSPredicate(value: true)
 
         do {
-            try sut.fetch(predicate: predicate) { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch(predicate: predicate, sortDescriptors: nil) { (entity: [Object]?) in print(entity?.count ?? 0) }
         } catch {}
 
 		XCTAssertTrue(getSpyRealm().forcedResult.filterPredicateArgument === predicate)
@@ -472,7 +472,7 @@ extension RealmContextTests {
 		let sort2 = SortDescriptor(key: "b", ascending: false)
 
         do {
-            try sut.fetch(sortDescriptors:[sort, sort2]) { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch(predicate: nil, sortDescriptors: [sort, sort2]) { (entity: [Object]?) in print(entity?.count ?? 0) }
         } catch {}
 
 		XCTAssertEqual(getSpyRealm().forcedResult.sortedCallsCount, 2)
@@ -483,7 +483,7 @@ extension RealmContextTests {
 		let sort2 = SortDescriptor(key: "b", ascending: false)
 
         do {
-            try sut.fetch(sortDescriptors:[sort, sort2]) { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch(predicate: nil, sortDescriptors: [sort, sort2]) { (entity: [Object]?) in print(entity?.count ?? 0) }
         } catch {}
 
 		XCTAssertEqual(getSpyRealm().forcedResult.sortedKeyPathArguments.first, "a")

--- a/Tests/Storages/Realm/RealmContextTests.swift
+++ b/Tests/Storages/Realm/RealmContextTests.swift
@@ -264,7 +264,7 @@ extension RealmContextTests {
 extension RealmContextTests {
 	func test_AddEntity_ObjectNotNil_RealmAddIsNotCalled() {
 		do {
-			try sut.add(DummyStorageEntity())
+			try sut.addOrUpdate(DummyStorageEntity())
 
 			XCTAssertEqual(getSpyRealm().addCallsCount, 0)
 		} catch {}
@@ -272,7 +272,7 @@ extension RealmContextTests {
 
 	func test_AddEntity_ObjectNil_RealmAddIsCalled() {
 		do {
-			try sut.add(Object())
+			try sut.addOrUpdate(Object())
 
 			XCTAssertEqual(getSpyRealm().addCallsCount, 1)
 		} catch {}
@@ -281,7 +281,7 @@ extension RealmContextTests {
 	func test_AddEntity_ObjectNil_RealmAddIsCalledWithRightArguments() {
 		do {
 			let obj = Object()
-			try sut.add(obj)
+			try sut.addOrUpdate(obj)
 
 			XCTAssertTrue(getSpyRealm().addObjectArguments?.first === obj)
 			XCTAssertFalse(getSpyRealm().addUpdatesArguments?.first ?? true)
@@ -290,7 +290,7 @@ extension RealmContextTests {
 
 	func test_AddEntity_EntityObject_CallsRealmWriteBlock() {
 		do {
-			try sut.add(Object())
+			try sut.addOrUpdate(Object())
 
 			XCTAssertTrue(getSpyRealm().isWriteCalled)
 		} catch {}
@@ -301,7 +301,7 @@ extension RealmContextTests {
 extension RealmContextTests {
 	func test_AddEntities_ObjectNotNil_RealmAddIsNotCalled() {
 		do {
-			try sut.add([DummyStorageEntity(), DummyStorageEntity()])
+			try sut.addOrUpdate([DummyStorageEntity(), DummyStorageEntity()])
 
 			XCTAssertEqual(getSpyRealm().addCallsCount, 0)
 		} catch {}
@@ -309,7 +309,7 @@ extension RealmContextTests {
 
 	func test_AddEntities_ObjectNil_RealmAddIsCalledTwice() {
 		do {
-			try sut.add([Object(), Object()])
+			try sut.addOrUpdate([Object(), Object()])
 
 			XCTAssertEqual(getSpyRealm().addCallsCount, 2)
 		} catch {}
@@ -319,7 +319,7 @@ extension RealmContextTests {
 		do {
 			let obj = Object()
 			let obj2 = Object()
-			try sut.add([obj, obj2])
+			try sut.addOrUpdate([obj, obj2])
 
 			XCTAssertTrue(getSpyRealm().addObjectArguments?.first === obj)
 			XCTAssertFalse(getSpyRealm().addUpdatesArguments?.first ?? true)
@@ -331,7 +331,7 @@ extension RealmContextTests {
 
 	func test_AddEntities_EntityObject_CallsRealmWriteBlock() {
 		do {
-			try sut.add(Object())
+			try sut.addOrUpdate(Object())
 
 			XCTAssertTrue(getSpyRealm().isWriteCalled)
 		} catch {}

--- a/Tests/Storages/Realm/RealmContextTests.swift
+++ b/Tests/Storages/Realm/RealmContextTests.swift
@@ -385,23 +385,11 @@ extension RealmContextTests {
 
 // MARK: - fetch()
 extension RealmContextTests {
-//	var objects = realm.objects(type: entityToFetch)
-//
-//	if let predicate = predicate {
-//		objects = objects.filter(predicate: predicate)
-//	}
-//
-//	if let sortDescriptors = sortDescriptors {
-//		for sortDescriptor in sortDescriptors {
-//			objects = objects.sorted(keyPath: sortDescriptor.key, ascending: sortDescriptor.ascending)
-//		}
-//	}
-
 	func test_Fetch_EntityNotObject_DoesNotCallsRealmObjects() {
 		sut.fetch { (entity: [DummyStorageEntity]?) in print(entity?.count ?? 0) }
 
 		XCTAssertFalse(getSpyRealm().isObjectsCalled)
-	}
+    }
 
 	func test_Fetch_EntityObject_CallsRealmObjects() {
 		sut.fetch { (entity: [Object]?) in print(entity?.count ?? 0) }

--- a/Tests/Storages/Realm/RealmContextTests.swift
+++ b/Tests/Storages/Realm/RealmContextTests.swift
@@ -295,6 +295,28 @@ extension RealmContextTests {
 			XCTAssertTrue(getSpyRealm().isWriteCalled)
 		} catch {}
 	}
+    
+    func test_AddEntity_EntityObject_UpdateIsNotCalled() {
+        do {
+            try sut.addOrUpdate(DummyStorageEntity())
+            
+            XCTAssertFalse(getSpyRealm().isUpdateCalledOnAdd)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func test_AddEntity_EntityObject_UpdateIsCalled() {
+        do {
+            
+            try sut.addOrUpdate(SpyRealmEntity())
+            try sut.addOrUpdate(SpyRealmEntity())
+            
+            XCTAssertTrue(getSpyRealm().isUpdateCalledOnAdd)
+        } catch {
+            XCTFail()
+        }
+    }
 }
 
 // MARK: - add(entities)

--- a/Tests/Storages/Realm/RealmContextTests.swift
+++ b/Tests/Storages/Realm/RealmContextTests.swift
@@ -411,7 +411,7 @@ extension RealmContextTests {
 extension RealmContextTests {
 	func test_Fetch_EntityNotObject_DoesNotCallsRealmObjects() {
         do {
-            try sut.fetch { (entity: [DummyStorageEntity]?) in print(entity?.count ?? 0) }
+            try sut.fetch { (_: [DummyStorageEntity]?) in }
         } catch {}
 
 		XCTAssertFalse(getSpyRealm().isObjectsCalled)
@@ -419,7 +419,7 @@ extension RealmContextTests {
 
 	func test_Fetch_EntityObject_CallsRealmObjects() {
         do {
-            try sut.fetch { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch { (_: [Object]?) in }
         } catch {}
 
 		XCTAssertTrue(getSpyRealm().isObjectsCalled)
@@ -427,7 +427,7 @@ extension RealmContextTests {
 
 	func test_Fetch_EntityObject_CallsRealmObjectsWithRightArgument() {
         do {
-            try sut.fetch { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch { (_: [Object]?) in }
         } catch {}
 
 		XCTAssertTrue(getSpyRealm().objectsTypeArgument is Object.Type)
@@ -435,7 +435,7 @@ extension RealmContextTests {
 
 	func test_Fetch_PredicateNil_DoesNotCallResultPredicate() {
         do {
-            try sut.fetch { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch { (_: [Object]?) in }
         } catch {}
 
 		XCTAssertFalse(getSpyRealm().forcedResult.isFilterCalled)
@@ -443,7 +443,7 @@ extension RealmContextTests {
 
 	func test_Fetch_PredicateNotNil_CallsResultPredicate() {
         do {
-            try sut.fetch(predicate: NSPredicate(value: true), sortDescriptors: nil) { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch(predicate: NSPredicate(value: true), sortDescriptors: nil) { (_: [Object]?) in }
         } catch {}
 
 		XCTAssertTrue(getSpyRealm().forcedResult.isFilterCalled)
@@ -453,7 +453,7 @@ extension RealmContextTests {
 		let predicate = NSPredicate(value: true)
 
         do {
-            try sut.fetch(predicate: predicate, sortDescriptors: nil) { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch(predicate: predicate, sortDescriptors: nil) { (_: [Object]?) in }
         } catch {}
 
 		XCTAssertTrue(getSpyRealm().forcedResult.filterPredicateArgument === predicate)
@@ -472,7 +472,7 @@ extension RealmContextTests {
 		let sort2 = SortDescriptor(key: "b", ascending: false)
 
         do {
-            try sut.fetch(predicate: nil, sortDescriptors: [sort, sort2]) { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch(predicate: nil, sortDescriptors: [sort, sort2]) { (_: [Object]?) in }
         } catch {}
 
 		XCTAssertEqual(getSpyRealm().forcedResult.sortedCallsCount, 2)
@@ -483,7 +483,7 @@ extension RealmContextTests {
 		let sort2 = SortDescriptor(key: "b", ascending: false)
 
         do {
-            try sut.fetch(predicate: nil, sortDescriptors: [sort, sort2]) { (entity: [Object]?) in print(entity?.count ?? 0) }
+            try sut.fetch(predicate: nil, sortDescriptors: [sort, sort2]) { (_: [Object]?) in }
         } catch {}
 
 		XCTAssertEqual(getSpyRealm().forcedResult.sortedKeyPathArguments.first, "a")
@@ -510,4 +510,13 @@ extension RealmContextTests {
 
 		waitForExpectations(timeout: 1)
 	}
+
+    func test_Fetch_PredicateAndDescriptionOmitted_DoesNotCallFilterAndSorted() {
+        do {
+            try sut.fetch { (_: [Object]?) in }
+        } catch {}
+
+        XCTAssertFalse(getSpyRealm().forcedResult.isFilterCalled)
+        XCTAssertEqual(getSpyRealm().forcedResult.sortedCallsCount, 0)
+    }
 }

--- a/Tests/Storages/Realm/TestDoubles/SpyRealm.swift
+++ b/Tests/Storages/Realm/TestDoubles/SpyRealm.swift
@@ -44,6 +44,8 @@ final class SpyRealm {
 	fileprivate(set) var addCallsCount = 0
 	fileprivate(set) var addObjectArguments: [Object]?
 	fileprivate(set) var addUpdatesArguments: [Bool]?
+    
+    fileprivate(set) var isUpdateCalledOnAdd = false
 
 	var isInWriteTransaction = false
 
@@ -71,6 +73,8 @@ extension SpyRealm: RealmType {
 		addCallsCount += 1
 		addObjectArguments?.append(object)
 		addUpdatesArguments?.append(update)
+        
+        isUpdateCalledOnAdd = update
 	}
 
 	func objects<T>(type: T.Type) -> RealmResultType {

--- a/Tests/Storages/Realm/TestDoubles/SpyRealmContext.swift
+++ b/Tests/Storages/Realm/TestDoubles/SpyRealmContext.swift
@@ -35,9 +35,9 @@ extension RealmContextType {
 	func deleteAll<T: StorageEntityType>(_ entityType: T.Type) throws {}
 	func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) {}
 	func update(transform: @escaping () -> Void) throws {}
-	func add<T>(_ entities: [T]) throws where T : StorageEntityType {}
+	func addOrUpdate<T>(_ entities: [T]) throws where T : StorageEntityType {}
 
-	func add<T>(_ entity: T) throws where T : StorageEntityType {}
+	func addOrUpdate<T>(_ entity: T) throws where T : StorageEntityType {}
 
 	func create<T: StorageEntityType>() -> T? {
 		return nil

--- a/Tests/Storages/Realm/TestDoubles/SpyRealmContext.swift
+++ b/Tests/Storages/Realm/TestDoubles/SpyRealmContext.swift
@@ -33,6 +33,7 @@ extension RealmContextType {
 	func delete<T: StorageEntityType>(_ entity: T) throws {}
 	func delete<T: StorageEntityType>(_ entities: [T]) throws {}
 	func deleteAll<T: StorageEntityType>(_ entityType: T.Type) throws {}
+    func fetch<T>(completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
 	func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) {}
 	func update(transform: @escaping () -> Void) throws {}
 	func addOrUpdate<T>(_ entities: [T]) throws where T : StorageEntityType {}

--- a/Tests/Storages/Realm/TestDoubles/SpyRealmEntity.swift
+++ b/Tests/Storages/Realm/TestDoubles/SpyRealmEntity.swift
@@ -1,0 +1,35 @@
+//
+//  SpyRealmEntity.swift
+//  StorageKit
+//
+//  Copyright (c) 2017 StorageKit (https://github.com/StorageKit)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Realm
+import RealmSwift
+
+final class SpyRealmEntity: Object {
+    var spyId: String = "123"
+    
+    override static func primaryKey() -> String? {
+        return "spyId"
+    }
+}


### PR DESCRIPTION
I think it's much more useful to update entities if they already exist, as the CoreData module already does.
