### PR TITLE
Pr 19

### DIFF
--- a/Example/Source/SubExamples/API response/APIResponseCoreDataViewController.swift
+++ b/Example/Source/SubExamples/API response/APIResponseCoreDataViewController.swift
@@ -52,7 +52,7 @@ class APIResponseCoreDataViewController: UIViewController {
 					} catch { return nil }
 				}
 
-				try? context.add(users)
+				try? context.addOrUpdate(users)
 
 				DispatchQueue.main.async {
 					completion()

--- a/Example/Source/SubExamples/API response/APIResponseRealmViewController.swift
+++ b/Example/Source/SubExamples/API response/APIResponseRealmViewController.swift
@@ -51,7 +51,7 @@ class APIResponseRealmViewController: UIViewController {
 
 				do {
 					try context.deleteAll(APIUserRealm.self)
-					try context.add(users)
+					try context.addOrUpdate(users)
 				} catch {
 					print(error)
 				}

--- a/Example/Source/SubExamples/ToDo App/Components/AddToDoViewController.swift
+++ b/Example/Source/SubExamples/ToDo App/Components/AddToDoViewController.swift
@@ -48,7 +48,7 @@ class AddToDoViewController: UIViewController {
                     if let task = todoTask, let name = self.taskNameTextField.text {
                         task.name = name
                         task.added = NSDate()
-                        try backgroundContext.add(task)
+                        try backgroundContext.addOrUpdate(task)
                     }
                 case .Realm:
                     let todoTask: RTodoTask? = try backgroundContext.create()
@@ -56,7 +56,7 @@ class AddToDoViewController: UIViewController {
                     if let task = todoTask, let name = self.taskNameTextField.text {
                         task.name = name
                         task.added = NSDate()
-                        try backgroundContext.add(task)
+                        try backgroundContext.addOrUpdate(task)
                     }
                 }
                 

--- a/Source/Core/Contexts/StorageContext.swift
+++ b/Source/Core/Contexts/StorageContext.swift
@@ -90,11 +90,12 @@ public protocol StorageWritableContext: class {
             try context.add(entity)
         } catch {}
         ```
+        If an entity with the same identifier already exists then the object is updated with `entity`
 
         - Parameter entity: Entity to add in the database.
         - Throws: The error depends on database used (CoreData and Realm).
     */
-    func add<T: StorageEntityType>(_ entity: T) throws
+    func addOrUpdate<T: StorageEntityType>(_ entity: T) throws
     
     /**
         Use this method to add an array of entities in the database.
@@ -113,11 +114,14 @@ public protocol StorageWritableContext: class {
         } catch {}
         ```
 
+        For each entity included in the array, if there an object already stored with the same identifier then this object 
+        is updated with the one taken from the array.
+
         - Parameter entities: Array of entities to add in the database.
         - Throws: The error depends on database used (CoreData and Realm).
     */
     
-    func add<T: StorageEntityType>(_ entities: [T]) throws
+    func addOrUpdate<T: StorageEntityType>(_ entities: [T]) throws
 }
 
 /// This protocol adds the functionality to fetch entities from the database.

--- a/Source/Storages/CoreData/Extensions/NSManagedObjectContext+StorageContext.swift
+++ b/Source/Storages/CoreData/Extensions/NSManagedObjectContext+StorageContext.swift
@@ -56,11 +56,11 @@ extension NSManagedObjectContext: StorageDeletableContext {
 
 // MARK: - StorageWritableContext
 extension NSManagedObjectContext: StorageWritableContext {
-    public func add<T: StorageEntityType>(_ entity: T) throws {
+    public func addOrUpdate<T: StorageEntityType>(_ entity: T) throws {
         try save()
     }
     
-    public func add<T: StorageEntityType>(_ entities: [T]) throws {
+    public func addOrUpdate<T: StorageEntityType>(_ entities: [T]) throws {
         try save()
     }
 

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -79,7 +79,7 @@ extension RealmContext {
             
             entities.lazy
                 .flatMap { return $0 as? Object }
-                .forEach { realm.add($0, update: false) }
+                .forEach { realm.add($0, update: true) }
         }
     }
 }

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -70,11 +70,11 @@ extension RealmContext {
         return entityToCreate.init() as? T
     }
     
-    func add<T: StorageEntityType>(_ entity: T) throws {
-        try add([entity])
+    func addOrUpdate<T: StorageEntityType>(_ entity: T) throws {
+        try addOrUpdate([entity])
     }
     
-    func add<T: StorageEntityType>(_ entities: [T]) throws {
+    func addOrUpdate<T: StorageEntityType>(_ entities: [T]) throws {
         try self.safeWriteAction {
             
             entities.lazy

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -79,7 +79,10 @@ extension RealmContext {
             
             entities.lazy
                 .flatMap { return $0 as? Object }
-                .forEach { realm.add($0, update: true) }
+                .forEach {
+                    let canUpdateIfExists = $0.objectSchema.primaryKeyProperty != nil
+                    realm.add($0, update: canUpdateIfExists)
+            }
         }
     }
 }

--- a/Tests/Core/TestDoubles/DummyStorageContext.swift
+++ b/Tests/Core/TestDoubles/DummyStorageContext.swift
@@ -46,9 +46,9 @@ extension DummyStorageContext: StorageUpdatableContext {
 }
 
 extension DummyStorageContext: StorageWritableContext {
-    func add<T>(_ entities: [T]) throws where T : StorageEntityType {}
+    func addOrUpdate<T>(_ entities: [T]) throws where T : StorageEntityType {}
 
-    func add<T>(_ entity: T) throws where T : StorageEntityType {}
+    func addOrUpdate<T>(_ entity: T) throws where T : StorageEntityType {}
 
     func create<T: StorageEntityType>() -> T? {
         return nil

--- a/Tests/Storages/CoreData/Extensions/NSManagedObjectContextStorageContextTests.swift
+++ b/Tests/Storages/CoreData/Extensions/NSManagedObjectContextStorageContextTests.swift
@@ -193,7 +193,7 @@ extension NSManagedObjectContextStorageContextTests {
 extension NSManagedObjectContextStorageContextTests {
     func test_Add_OneEntity_CallsSuperSave() {
         do {
-            try sut.add(DummyStorageEntity())
+            try sut.addOrUpdate(DummyStorageEntity())
         } catch {
             XCTFail()
         }
@@ -203,7 +203,7 @@ extension NSManagedObjectContextStorageContextTests {
 
     func test_Add_ArrayOfEntities_CallsSuperSave() {
         do {
-            try sut.add([DummyStorageEntity(), DummyStorageEntity(), DummyStorageEntity()])
+            try sut.addOrUpdate([DummyStorageEntity(), DummyStorageEntity(), DummyStorageEntity()])
         } catch {
             XCTFail()
         }

--- a/Tests/Storages/CoreData/TestDoubles/SpyManagedObjectContext.swift
+++ b/Tests/Storages/CoreData/TestDoubles/SpyManagedObjectContext.swift
@@ -105,5 +105,5 @@ extension SpyManagedObjectContext {
     
     func create<T: StorageEntityType>() -> T? { return nil }
     
-    func add<T>(_ entity: T) throws { }
+    func addOrUpdate<T>(_ entity: T) throws { }
 }

--- a/Tests/Storages/Realm/RealmContextTests.swift
+++ b/Tests/Storages/Realm/RealmContextTests.swift
@@ -264,7 +264,7 @@ extension RealmContextTests {
 extension RealmContextTests {
 	func test_AddEntity_ObjectNotNil_RealmAddIsNotCalled() {
 		do {
-			try sut.add(DummyStorageEntity())
+			try sut.addOrUpdate(DummyStorageEntity())
 
 			XCTAssertEqual(getSpyRealm().addCallsCount, 0)
 		} catch {}
@@ -272,7 +272,7 @@ extension RealmContextTests {
 
 	func test_AddEntity_ObjectNil_RealmAddIsCalled() {
 		do {
-			try sut.add(Object())
+			try sut.addOrUpdate(Object())
 
 			XCTAssertEqual(getSpyRealm().addCallsCount, 1)
 		} catch {}
@@ -281,7 +281,7 @@ extension RealmContextTests {
 	func test_AddEntity_ObjectNil_RealmAddIsCalledWithRightArguments() {
 		do {
 			let obj = Object()
-			try sut.add(obj)
+			try sut.addOrUpdate(obj)
 
 			XCTAssertTrue(getSpyRealm().addObjectArguments?.first === obj)
 			XCTAssertFalse(getSpyRealm().addUpdatesArguments?.first ?? true)
@@ -290,7 +290,7 @@ extension RealmContextTests {
 
 	func test_AddEntity_EntityObject_CallsRealmWriteBlock() {
 		do {
-			try sut.add(Object())
+			try sut.addOrUpdate(Object())
 
 			XCTAssertTrue(getSpyRealm().isWriteCalled)
 		} catch {}
@@ -301,7 +301,7 @@ extension RealmContextTests {
 extension RealmContextTests {
 	func test_AddEntities_ObjectNotNil_RealmAddIsNotCalled() {
 		do {
-			try sut.add([DummyStorageEntity(), DummyStorageEntity()])
+			try sut.addOrUpdate([DummyStorageEntity(), DummyStorageEntity()])
 
 			XCTAssertEqual(getSpyRealm().addCallsCount, 0)
 		} catch {}
@@ -309,7 +309,7 @@ extension RealmContextTests {
 
 	func test_AddEntities_ObjectNil_RealmAddIsCalledTwice() {
 		do {
-			try sut.add([Object(), Object()])
+			try sut.addOrUpdate([Object(), Object()])
 
 			XCTAssertEqual(getSpyRealm().addCallsCount, 2)
 		} catch {}
@@ -319,7 +319,7 @@ extension RealmContextTests {
 		do {
 			let obj = Object()
 			let obj2 = Object()
-			try sut.add([obj, obj2])
+			try sut.addOrUpdate([obj, obj2])
 
 			XCTAssertTrue(getSpyRealm().addObjectArguments?.first === obj)
 			XCTAssertFalse(getSpyRealm().addUpdatesArguments?.first ?? true)
@@ -331,7 +331,7 @@ extension RealmContextTests {
 
 	func test_AddEntities_EntityObject_CallsRealmWriteBlock() {
 		do {
-			try sut.add(Object())
+			try sut.addOrUpdate(Object())
 
 			XCTAssertTrue(getSpyRealm().isWriteCalled)
 		} catch {}

--- a/Tests/Storages/Realm/TestDoubles/SpyRealmContext.swift
+++ b/Tests/Storages/Realm/TestDoubles/SpyRealmContext.swift
@@ -35,9 +35,9 @@ extension RealmContextType {
 	func deleteAll<T: StorageEntityType>(_ entityType: T.Type) throws {}
 	func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) {}
 	func update(transform: @escaping () -> Void) throws {}
-	func add<T>(_ entities: [T]) throws where T : StorageEntityType {}
+	func addOrUpdate<T>(_ entities: [T]) throws where T : StorageEntityType {}
 
-	func add<T>(_ entity: T) throws where T : StorageEntityType {}
+	func addOrUpdate<T>(_ entity: T) throws where T : StorageEntityType {}
 
 	func create<T: StorageEntityType>() -> T? {
 		return nil


### PR DESCRIPTION
## Goal
Add the possibility to `update` an object on `add`, it it already exists.

## Approach
the `add` method implemented in `Realm` now includes the possibility to update an entity if it already exists with the same identifier

#### Open Questions and Pre-Merge TODOs
- [x] This branch is unit tested
- [x] This branch is updated with develop
- [x] The documentation/Readme is up to date with the changes of this branch