### PR TITLE
Move fetch without parameters in extension

### DIFF
--- a/Source/Core/Contexts/StorageContext.swift
+++ b/Source/Core/Contexts/StorageContext.swift
@@ -170,6 +170,12 @@ public protocol StorageReadableContext: class {
     func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) throws
 }
 
+public extension StorageReadableContext {
+    func fetch<T: StorageEntityType>(completion: @escaping FetchCompletionClosure<T>) throws {
+        try self.fetch(predicate: nil, sortDescriptors: nil, completion: completion)
+    }
+}
+
 /// This protocol adds the functionality to update entities in the database.
 public protocol StorageUpdatableContext: class {
     

--- a/Source/Storages/CoreData/Extensions/NSManagedObjectContext+StorageContext.swift
+++ b/Source/Storages/CoreData/Extensions/NSManagedObjectContext+StorageContext.swift
@@ -102,10 +102,6 @@ extension NSManagedObjectContext: StorageUpdatableContext {
 
 // MARK: - StorageReadableContext
 extension NSManagedObjectContext: StorageReadableContext {
-    public func fetch<T>(completion: @escaping FetchCompletionClosure<T>) throws where T : StorageEntityType {
-        return try fetch(predicate: nil, sortDescriptors: nil, completion: completion)
-    }
-
 	public func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) throws {
         guard T.self is NSManagedObject.Type else {
             throw StorageKitErrors.Entity.wrongType

--- a/Source/Storages/Realm/Extensions/Object+StorageEntityType.swift
+++ b/Source/Storages/Realm/Extensions/Object+StorageEntityType.swift
@@ -26,5 +26,8 @@
 import RealmSwift
 
 extension Object: StorageEntityType {
-    @nonobjc public static var name: String = ""
+    
+    @nonobjc public static var name: String {
+        return self.description()
+    }
 }

--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -105,10 +105,6 @@ extension RealmContext {
 
 // MARK: - StorageReadableContext
 extension RealmContext {
-    func fetch<T>(completion: @escaping FetchCompletionClosure<T>) throws where T : StorageEntityType {
-        return try fetch(predicate: nil, sortDescriptors: nil, completion: completion)
-    }
-    
     func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) throws {
 
         guard let entityToFetch = T.self as? Object.Type else {

--- a/Tests/Core/TestDoubles/DummyStorageContext.swift
+++ b/Tests/Core/TestDoubles/DummyStorageContext.swift
@@ -38,9 +38,6 @@ extension DummyStorageContext: StorageDeletableContext {
 }
 
 extension DummyStorageContext: StorageReadableContext {
-
-    func fetch<T>(completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
-
     func fetch<T: StorageEntityType>(predicate: NSPredicate? = nil, sortDescriptors: [SortDescriptor]? = nil, completion: @escaping FetchCompletionClosure<T>) {}
 }
 

--- a/Tests/Core/TestDoubles/DummyStorageContextWithoutFetch.swift
+++ b/Tests/Core/TestDoubles/DummyStorageContextWithoutFetch.swift
@@ -38,7 +38,6 @@ extension DummyStorageContextWithoutFetch: StorageDeletableContext {
 }
 
 extension DummyStorageContextWithoutFetch: StorageReadableContext {
-    func fetch<T>(completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
     func fetch<T>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
 }
 

--- a/Tests/Storages/CoreData/TestDoubles/SpyManagedObjectContext.swift
+++ b/Tests/Storages/CoreData/TestDoubles/SpyManagedObjectContext.swift
@@ -99,7 +99,6 @@ extension SpyManagedObjectContext {
     func delete<T: StorageEntityType>(_ entities: [T]) throws {}
     func deleteAll<T: StorageEntityType>(_ entityType: T.Type) throws {}
     
-    func fetch<T>(completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
     func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) {}
 
     func update(transform: @escaping () -> Void) throws {}

--- a/Tests/Storages/Realm/TestDoubles/SpyRealmContext.swift
+++ b/Tests/Storages/Realm/TestDoubles/SpyRealmContext.swift
@@ -33,7 +33,6 @@ extension RealmContextType {
 	func delete<T: StorageEntityType>(_ entity: T) throws {}
 	func delete<T: StorageEntityType>(_ entities: [T]) throws {}
 	func deleteAll<T: StorageEntityType>(_ entityType: T.Type) throws {}
-    func fetch<T>(completion: @escaping ([T]?) -> Void) throws where T : StorageEntityType {}
 	func fetch<T: StorageEntityType>(predicate: NSPredicate?, sortDescriptors: [SortDescriptor]?, completion: @escaping FetchCompletionClosure<T>) {}
 	func update(transform: @escaping () -> Void) throws {}
 	func addOrUpdate<T>(_ entities: [T]) throws where T : StorageEntityType {}


### PR DESCRIPTION
## Goal
Move fetch without parameters in extension to avoid the implementation in Realm and Core Data

## Approach


#### Open Questions and Pre-Merge TODOs
- [x] This branch is unit tested
- [x] This branch is updated with develop
- [x] The documentation/Readme is up to date with the changes of this branch