### PR TITLE
Add sorting with array as argument

### DIFF
--- a/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
+++ b/Source/Storages/Realm/Extensions/RealmContext+StorageContext.swift
@@ -116,11 +116,9 @@ extension RealmContext {
         if let predicate = predicate {
             objects = objects.filter(predicate: predicate)
         }
-        
+
         if let sortDescriptors = sortDescriptors {
-            for sortDescriptor in sortDescriptors {
-                objects = objects.sorted(keyPath: sortDescriptor.key, ascending: sortDescriptor.ascending)
-            }
+            objects = objects.sorted(with: sortDescriptors)
         }
         
         completion(objects.toArray.flatMap { $0 as? T })

--- a/Source/Storages/Realm/Extensions/Results+RealmResultType.swift
+++ b/Source/Storages/Realm/Extensions/Results+RealmResultType.swift
@@ -34,8 +34,10 @@ extension Results: RealmResultType {
 		return filter(predicate)
 	}
 
-	func sorted(keyPath: String, ascending: Bool) -> RealmResultType {
-		return sorted(byKeyPath: keyPath, ascending: ascending)
-	}
-
+    func sorted(with sortDescriptors: [SortDescriptor]) -> RealmResultType {
+        let realmDescriptors = sortDescriptors.flatMap {
+            return RealmSwift.SortDescriptor(keyPath: $0.key, ascending: $0.ascending)
+        }
+        return sorted(by: realmDescriptors)
+    }
 }

--- a/Source/Storages/Realm/StackObjects/RealmResultType.swift
+++ b/Source/Storages/Realm/StackObjects/RealmResultType.swift
@@ -29,5 +29,5 @@ protocol RealmResultType: class {
 	var toArray: [Object] { get }
 
 	func filter(predicate: NSPredicate) -> RealmResultType
-	func sorted(keyPath: String, ascending: Bool) -> RealmResultType
+    func sorted(with sortDescriptors: [SortDescriptor]) -> RealmResultType
 }

--- a/Tests/Storages/Realm/RealmContextTests.swift
+++ b/Tests/Storages/Realm/RealmContextTests.swift
@@ -475,7 +475,7 @@ extension RealmContextTests {
             try sut.fetch(predicate: nil, sortDescriptors: [sort, sort2]) { (_: [Object]?) in }
         } catch {}
 
-		XCTAssertEqual(getSpyRealm().forcedResult.sortedCallsCount, 2)
+		XCTAssertEqual(getSpyRealm().forcedResult.sortedCallsCount, 1)
 	}
 
 	func test_Fetch_DescriptorsNotNil_CallsResultDescriptorsWithRightArguments() {
@@ -486,11 +486,11 @@ extension RealmContextTests {
             try sut.fetch(predicate: nil, sortDescriptors: [sort, sort2]) { (_: [Object]?) in }
         } catch {}
 
-		XCTAssertEqual(getSpyRealm().forcedResult.sortedKeyPathArguments.first, "a")
-		XCTAssertEqual(getSpyRealm().forcedResult.sortedAscendingArguments.first, true)
+		XCTAssertEqual(getSpyRealm().forcedResult.sortedDescriptorsArguments?.first?.key, "a")
+		XCTAssertEqual(getSpyRealm().forcedResult.sortedDescriptorsArguments?.first?.ascending, true)
 
-		XCTAssertEqual(getSpyRealm().forcedResult.sortedKeyPathArguments[1], "b")
-		XCTAssertEqual(getSpyRealm().forcedResult.sortedAscendingArguments[1], false)
+		XCTAssertEqual(getSpyRealm().forcedResult.sortedDescriptorsArguments?[1].key, "b")
+		XCTAssertEqual(getSpyRealm().forcedResult.sortedDescriptorsArguments?[1].ascending, false)
 	}
 
 	func test_Fetch_EntityObject_ReturnsRightEntities() {

--- a/Tests/Storages/Realm/TestDoubles/SpyRealmResult.swift
+++ b/Tests/Storages/Realm/TestDoubles/SpyRealmResult.swift
@@ -26,7 +26,7 @@
 @testable import StorageKit
 
 import Realm
-import RealmSwift
+import class RealmSwift.Object
 
 final class SpyRealmResult {
 	var toArray = [Object]()
@@ -35,8 +35,7 @@ final class SpyRealmResult {
 	fileprivate(set) var filterPredicateArgument: NSPredicate?
 
 	fileprivate(set) var sortedCallsCount = 0
-	fileprivate(set) var sortedKeyPathArguments = [String]()
-	fileprivate(set) var sortedAscendingArguments = [Bool]()
+    fileprivate(set) var sortedDescriptorsArguments: [SortDescriptor]?
 }
 
 extension SpyRealmResult: RealmResultType {
@@ -47,10 +46,9 @@ extension SpyRealmResult: RealmResultType {
 		return self
 	}
 
-	func sorted(keyPath: String, ascending: Bool) -> RealmResultType {
+	func sorted(with sortDescriptors: [SortDescriptor]) -> RealmResultType {
 		sortedCallsCount += 1
-		sortedKeyPathArguments.append(keyPath)
-		sortedAscendingArguments.append(ascending)
+		sortedDescriptorsArguments = sortDescriptors
 
 		return self
 	}


### PR DESCRIPTION
## Goal

With the previous approach, if we sorted with multiple fields, the sorting would have been applied just to the last `sortDescriptor` element.

## Approach

Add sorting with array as argument.

#### Open Questions and Pre-Merge TODOs
- [x] This branch is unit tested
- [x] This branch is updated with develop
- [x] The documentation/Readme is up to date with the changes of this branch